### PR TITLE
feat: assign and display different colors for each players turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Click on the shortcut to start the application.
 
     python3 darts-wled.py -WEPS 192.168.1.111 -CON 192.168.1.170:8079 -PCO true -PCA '{"chazensign": "blue", "kim": "hotpink"}' -B ps|2 -M ps|3 -G ps|3 -IDE ps|4
 
+
+
 ### Arguments
 
 - -CON / --connection [OPTIONAL] [Default: "127.0.0.1:8079"] 
@@ -128,7 +130,7 @@ Click on the shortcut to start the application.
 - -G / --game_won_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -M / --match_won_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -B / --busted_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
-- -PCO / --player_colors_on [OPTIONAL] [Default: False] [Possible values: See below]
+- -PCO / --player_colors_on [OPTIONAL] [Default: 0] [Possible values: See below]
 - -PCA / --player_color_assignments [OPTIONAL] [Default: None] [Possible values: See below]
 - -PJ / --player_joined_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -PL / --player_left_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
@@ -189,11 +191,11 @@ Define one effect/preset/playlist or a list. If you define a list, the program w
 
 *`-PCA / --player_color_assignments`*
 
-A json dict of player names to specific color assignments. If provided, -PCO is treated as True and remaining players will given a color. Requires a format of `'{"<player-name>": "blue"}'`.
+A comma separated string of player names to specific color assignments. If provided, -PCO is treated as True and remaining players will given a color. Example `"playername1:blue,playername2:orange"`.
 
 *`-PCO / --player_colors_on`*
 
-Up to 10 players are assigned a color when a match starts, that color is display when it is that players turn to throw.
+If '1', up to 10 players are assigned a color when a match starts, that color is display when it is that players turn to throw.
 
 *`-PJ / --player_joined_effects`*
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ Click on the shortcut to start the application.
 
 #### Example: Linux
 
-    python3 darts-wled.py -WEPS "your-wled-ip"
-
-
+    python3 darts-wled.py -WEPS 192.168.1.111 -CON 192.168.1.170:8079 -PCO true -PCA '{"chazensign": "blue", "kim": "hotpink"}' -B ps|2 -M ps|3 -G ps|3 -IDE ps|4
 
 ### Arguments
 
@@ -130,6 +128,8 @@ Click on the shortcut to start the application.
 - -G / --game_won_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -M / --match_won_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -B / --busted_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
+- -PCO / --player_colors_on [OPTIONAL] [Default: False] [Possible values: See below]
+- -PCA / --player_color_assignments [OPTIONAL] [Default: None] [Possible values: See below]
 - -PJ / --player_joined_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -PL / --player_left_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
 - -S{0-180} / --score_{0-180}_effects [OPTIONAL] [MULTIPLE ENTRIES POSSIBLE] [Default: None] [Possible values: See below] 
@@ -186,6 +186,14 @@ Define one effect/preset/playlist or a list. If you define a list, the program w
 
 Controls your wled(s) when a bust occurs.
 Define one effect/preset/playlist or a list. If you define a list, the program will randomly choose at runtime. For examples see below!
+
+*`-PCA / --player_color_assignments`*
+
+A json dict of player names to specific color assignments. If provided, -PCO is treated as True and remaining players will given a color. Requires a format of `'{"<player-name>": "blue"}'`.
+
+*`-PCO / --player_colors_on`*
+
+Up to 10 players are assigned a color when a match starts, that color is display when it is that players turn to throw.
 
 *`-PJ / --player_joined_effects`*
 

--- a/color_constants.py
+++ b/color_constants.py
@@ -1124,3 +1124,4 @@ colors['yellow2'] = YELLOW2
 colors['yellow3'] = YELLOW3
 colors['yellow4'] = YELLOW4
 colors = OrderedDict(sorted(colors.items(), key=lambda t: t[0]))
+playerColorOptions = list(['blue', 'red1', 'green', 'orange', 'purple', 'teal', 'magenta', 'yellow', 'limegreen', 'hotpink'])

--- a/color_constants.py
+++ b/color_constants.py
@@ -1124,4 +1124,3 @@ colors['yellow2'] = YELLOW2
 colors['yellow3'] = YELLOW3
 colors['yellow4'] = YELLOW4
 colors = OrderedDict(sorted(colors.items(), key=lambda t: t[0]))
-playerColorOptions = list(['blue', 'red1', 'green', 'orange', 'purple', 'teal', 'magenta', 'yellow', 'limegreen', 'hotpink'])

--- a/darts-wled.py
+++ b/darts-wled.py
@@ -6,11 +6,11 @@ import argparse
 import threading
 import logging
 from color_constants import colors as WLED_COLORS
-from color_constants import playerColorOptions as PLAYER_COLOR_OPTIONS
 import time
 import requests
 import socketio
 import websocket
+import player_colors
 
 
 sh = logging.StreamHandler()
@@ -39,9 +39,6 @@ EFFECT_PARAMETER_SEPARATOR = "|"
 BOGEY_NUMBERS = [169, 168, 166, 165, 163, 162, 159]
 SUPPORTED_CRICKET_FIELDS = [15, 16, 17, 18, 19, 20, 25]
 SUPPORTED_GAME_VARIANTS = ['X01', 'Cricket', 'Random Checkout']
-
-DEFAULT_PLAYER_COLOR_ASSIGNMENTS = dict()
-MATCH_PLAYER_COLOR_ASSIGNMENTS = dict()
 
 def ppi(message, info_object = None, prefix = '\r\n'):
     logger.info(prefix + str(message))
@@ -287,6 +284,8 @@ def parse_effects_argument(effects_argument, custom_duration_possible = True):
 
     return parsed_list   
 
+
+
 def parse_score_area_effects_argument(score_area_effects_arguments):
     if score_area_effects_arguments == None:
         return score_area_effects_arguments
@@ -296,29 +295,8 @@ def parse_score_area_effects_argument(score_area_effects_arguments):
         return ((int(area[0]), int(area[1])), parse_effects_argument(score_area_effects_arguments[1:]))
     else:
         raise Exception(score_area_effects_arguments[0] + ' is not a valid score-area')
-
-def handle_player_color_assignment(player_name):
-    global MATCH_PLAYER_COLOR_ASSIGNMENTS
-
-    if player_name in MATCH_PLAYER_COLOR_ASSIGNMENTS:
-        return
-    else:
-        MATCH_PLAYER_COLOR_ASSIGNMENTS[player_name] = PLAYER_COLOR_OPTIONS[len(MATCH_PLAYER_COLOR_ASSIGNMENTS)]
-
-def reset_match_player_color_map():
-    global MATCH_PLAYER_COLOR_ASSIGNMENTS
-
-    MATCH_PLAYER_COLOR_ASSIGNMENTS = DEFAULT_PLAYER_COLOR_ASSIGNMENTS.copy()
-
-def assign_match_player_colors(msg):
-    global MATCH_PLAYER_COLOR_ASSIGNMENTS
-    match_players = msg['players']
-
-    reset_match_player_color_map()
-
-    for player in match_players:
-        if MATCH_PLAYER_COLOR_ASSIGNMENTS.get(player["name"]) == None:
-            handle_player_color_assignment(player["name"])
+        
+        
 
 def process_lobby(msg):
     if msg['action'] == 'player-joined' and PLAYER_JOINED_EFFECTS is not None:
@@ -328,20 +306,12 @@ def process_lobby(msg):
         control_wled(PLAYER_LEFT_EFFECTS, 'Player left!')
         MATCH_PLAYER_COLOR_ASSIGNMENTS.pop(msg['event'], None)
 
+
 def process_player_change(msg):
-    global MATCH_PLAYER_COLOR_ASSIGNMENTS
-
-    if len(MATCH_PLAYER_COLOR_ASSIGNMENTS) == 0:
-        MATCH_PLAYER_COLOR_ASSIGNMENTS = DEFAULT_PLAYER_COLOR_ASSIGNMENTS
-
-    playerName = msg['player']
-
-    if MATCH_PLAYER_COLOR_ASSIGNMENTS.get(playerName) is None:
-        handle_player_color_assignment(playerName)
-
-    nextColor = MATCH_PLAYER_COLOR_ASSIGNMENTS.get(playerName)
+    nextColor = player_colors.get_next(msg)
 
     control_wled(None, ptext='Next-player', bss_requested=False, color=WLED_COLORS[nextColor])
+    
 
 def process_variant_x01(msg):
     global MATCH_PLAYER_COLOR_ASSIGNMENTS
@@ -387,15 +357,14 @@ def process_variant_x01(msg):
 
     elif msg['event'] == 'match-started':
         if PLAYER_COLORS_ON == True:
-            assign_match_player_colors(msg)
-            process_player_change(msg)
+            player_colors.assign_match(msg)
 
         elif EFFECT_DURATION == 0:
             control_wled(IDLE_EFFECT, 'Match-started', bss_requested=False)
 
     elif msg['event'] == 'game-started':
         if PLAYER_COLORS_ON == True:
-            assign_match_player_colors(msg)
+            player_colors.assign_match(msg)
             process_player_change(msg)
 
         if EFFECT_DURATION == 0:
@@ -417,7 +386,8 @@ def message(msg):
     try:
         # ppi(message)
         if 'event' in msg and msg['event'] == 'unsubscribed':
-            reset_match_player_color_map()
+            player_colors.reset_assignments()
+
             control_wled(IDLE_EFFECT, 'Unsubscribed', bss_requested=False)
         if('game' in msg and 'mode' in msg['game']):
             mode = msg['game']['mode']
@@ -468,8 +438,8 @@ if __name__ == "__main__":
     ap.add_argument("-G", "--game_won_effects", default=None, required=False, nargs='*', help="WLED effect-definition when game won occurs")
     ap.add_argument("-M", "--match_won_effects", default=None, required=False, nargs='*', help="WLED effect-definition when match won occurs")
     ap.add_argument("-B", "--busted_effects", default=None, required=False, nargs='*', help="WLED effect-definition when bust occurs")
-    ap.add_argument( "-PCA", "--player_color_assignmets", required=False, help="A json dict of player names with specific color assignments. If provided, -PCO is treated as True.")
-    ap.add_argument("-PCO", "--player_colors_on", type=bool, default=False, required=False, help="Up to 10 players are assigned a color, that color is display when it is that players turn to throw")
+    ap.add_argument( "-PCA", "--player_color_assignmets", required=False, help="A comma separated string of player names with specific color assignments. If provided, -PCO is treated as '1'.")
+    ap.add_argument("-PCO", "--player_colors_on", type=int, choices=range(0,2), default=0, required=False, help="If '1', up to 10 players are assigned a color, that color is displayed when it is that player's turn to throw.")
     ap.add_argument("-PJ", "--player_joined_effects", default=None, required=False, nargs='*', help="WLED effect-definition when player-join occurs")
     ap.add_argument("-PL", "--player_left_effects", default=None, required=False, nargs='*', help="WLED effect-definition when player-left occurs")
     for v in range(0, 181):
@@ -523,9 +493,10 @@ if __name__ == "__main__":
     PLAYER_COLORS_ON = args['player_colors_on']
 
     if args['player_color_assignmets'] is not None:
-        logger.info('PLAYER_COLOR_ASSIGNMENTS: ' + args['player_color_assignmets'])
-        DEFAULT_PLAYER_COLOR_ASSIGNMENTS = json.loads(args['player_color_assignmets'])
+        DEFAULT_PLAYER_COLOR_ASSIGNMENTS = player_colors.parse_arguments(args['player_color_assignmets'])
         PLAYER_COLORS_ON = True
+        ppi('Player color assignments are: ' + str(DEFAULT_PLAYER_COLOR_ASSIGNMENTS))
+
 
     WLED_EFFECTS = list()
     try:     

--- a/player_colors.py
+++ b/player_colors.py
@@ -1,0 +1,84 @@
+# player-colors.py - Assigns colors to players in a match
+
+PLAYER_COLOR_OPTIONS = list(['blue', 'red1', 'green', 'orange', 'purple', 'teal', 'magenta', 'yellow', 'limegreen', 'hotpink'])
+PLAYER_ARGUMENTS_SEPARATOR = ','
+PLAYER_COLOR_SEPARATOR = ':'
+DEFAULT_PLAYER_COLOR_ASSIGNMENTS = dict()
+MATCH_PLAYER_COLOR_ASSIGNMENTS = dict()
+
+def parse_arguments(player_color_arguments):
+    global DEFAULT_PLAYER_COLOR_ASSIGNMENTS
+    
+    if player_color_arguments == None:
+        return player_color_arguments
+    
+    player_color_assignments = player_color_arguments.split(PLAYER_ARGUMENTS_SEPARATOR)
+
+    DEFAULT_PLAYER_COLOR_ASSIGNMENTS = dict()
+
+    for player_color_assignment in player_color_assignments:
+        player_color_assignment_params = player_color_assignment.split(PLAYER_COLOR_SEPARATOR)
+        player_name = player_color_assignment_params[0].strip()
+        player_color = player_color_assignment_params[1].strip()
+
+        DEFAULT_PLAYER_COLOR_ASSIGNMENTS[player_name] = player_color
+
+    return DEFAULT_PLAYER_COLOR_ASSIGNMENTS
+
+
+
+def assign(player_name):
+    global MATCH_PLAYER_COLOR_ASSIGNMENTS
+
+    if player_name in MATCH_PLAYER_COLOR_ASSIGNMENTS:
+        return 
+    else:
+        MATCH_PLAYER_COLOR_ASSIGNMENTS[player_name] = PLAYER_COLOR_OPTIONS[len(MATCH_PLAYER_COLOR_ASSIGNMENTS)]
+
+
+
+def reset_assignments():
+    global MATCH_PLAYER_COLOR_ASSIGNMENTS
+
+    MATCH_PLAYER_COLOR_ASSIGNMENTS = DEFAULT_PLAYER_COLOR_ASSIGNMENTS.copy()
+
+
+
+def assign_match(msg):
+    global MATCH_PLAYER_COLOR_ASSIGNMENTS
+    host_player_id = msg['players'][0]['host']['id']
+    match_players = msg['players']
+
+    reset_assignments()
+    host_player_is_in_players = False
+    for player in match_players:
+        if player['id'] == host_player_id:
+            host_player_is_in_players = True
+            break
+
+    if not host_player_is_in_players:
+        match_players.insert(0,msg['players'][0]['host'])
+
+    for player in match_players:
+        player_name = player['name']
+        if MATCH_PLAYER_COLOR_ASSIGNMENTS.get(player["name"]) == None:
+            assign(player_name)
+
+    return MATCH_PLAYER_COLOR_ASSIGNMENTS
+
+
+
+def get_next(msg):
+    global MATCH_PLAYER_COLOR_ASSIGNMENTS
+
+    if len(MATCH_PLAYER_COLOR_ASSIGNMENTS) == 0:
+        MATCH_PLAYER_COLOR_ASSIGNMENTS = DEFAULT_PLAYER_COLOR_ASSIGNMENTS
+
+    playerName = msg['player']
+
+    if MATCH_PLAYER_COLOR_ASSIGNMENTS.get(playerName) is None:
+        assign(playerName)
+
+    nextColor = MATCH_PLAYER_COLOR_ASSIGNMENTS.get(playerName)
+
+    return nextColor


### PR DESCRIPTION
`ap.add_argument( "-PCA", "--player_color_assignmets", required=False, help="A json dict of player names with specific color assignments. If provided, -PCO is treated as True.")
    ap.add_argument("-PCO", "--player_colors_on", type=bool, default=False, required=False, help="Up to 10 players are assigned a color, that color is display when it is that players turn to throw")`